### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.freedesktop.fwupd.json
+++ b/org.freedesktop.fwupd.json
@@ -14,10 +14,6 @@
     "--system-talk-name=org.freedesktop.fwupd",
     "--system-talk-name=org.freedesktop.UPower"
   ],
-  "build-options": {
-      "cflags": "-O2 -g",
-      "cxxflags": "-O2 -g"
-  },
   "cleanup": [
     "*.a",
     "*.la",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.