### PR TITLE
Remove installing flathub.json

### DIFF
--- a/org.freedesktop.fwupd.json
+++ b/org.freedesktop.fwupd.json
@@ -287,19 +287,6 @@
       ]
     },
     {
-      "name": "flathub-json",
-      "buildsystem": "simple",
-      "build-commands": [
-        "install -Dm644 flathub.json /app/flathub.json"
-      ],
-      "sources": [
-        {
-          "type": "file",
-          "path": "flathub.json"
-        }
-      ]
-    },
-    {
       "name": "fwupd",
       "buildsystem": "meson",
       "config-opts": [


### PR DESCRIPTION
skip-appstream-check was removed from linter last year and console applications skips checks automatically based on heuristics