### PR TITLE
Remove {skip,only}-arches

### DIFF
--- a/org.freedesktop.fwupd.json
+++ b/org.freedesktop.fwupd.json
@@ -33,10 +33,6 @@
     "modules": [
         {
             "name": "gnu-efi",
-            "only-arches": [
-                "aarch64",
-                "x86_64"
-            ],
             "buildsystem": "simple",
             "build-options": {
                 "ldflags-override": true
@@ -277,10 +273,6 @@
         {
             "name": "fwupd-efi",
             "buildsystem": "meson",
-            "skip-arches": [
-                "i386",
-                "arm"
-            ],
             "build-options": {
                 "ldflags-override": true
             },


### PR DESCRIPTION
No point. The skipped arches have no longer been built for over half a decade. (and the only one are the one we build)