### PR TITLE
Use libxmlb module from runtime

### DIFF
--- a/org.freedesktop.fwupd.json
+++ b/org.freedesktop.fwupd.json
@@ -67,31 +67,6 @@
             ]
         },
         {
-            "name": "libxmlb",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dintrospection=false",
-                "-Dgtkdoc=false",
-                "-Dtests=false",
-                "-Dstemmer=false",
-                "-Dcli=false",
-                "--sysconfdir=/app/etc",
-                "--localstatedir=/var/data"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/hughsie/libxmlb/releases/download/0.3.25/libxmlb-0.3.25.tar.xz",
-                    "sha256": "77f2768c9debd2e946173cdf9465efd987849805e7c58251c5772ea728a61d9a",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 179028,
-                        "url-template": "https://github.com/hughsie/libxmlb/releases/download/$version/libxmlb-$version.tar.xz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "libmbim",
             "buildsystem": "meson",
             "cleanup": [


### PR DESCRIPTION
GNOME runtime version 49 (based on the Freedesktop runtime version 25.08) appears to provide the libxmlb module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/org.freedesktop.fwupd/issues/117